### PR TITLE
docs: update README to reflect actual ORION mobile implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,153 @@
-This is a new [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
+# ORION Mobile
 
-# Getting Started
+ORION is a personal AI assistant Android app built with **React Native 0.76**. It features JWT-based authentication, real-time chat with an AI backend (Groq / Llama3-70B), persistent message history, and a clean dark-themed UI.
 
->**Note**: Make sure you have completed the [React Native - Environment Setup](https://reactnative.dev/docs/environment-setup) instructions till "Creating a new application" step, before proceeding.
+---
 
-## Step 1: Start the Metro Server
+## Tech Stack
 
-First, you will need to start **Metro**, the JavaScript _bundler_ that ships _with_ React Native.
+| Layer | Technology |
+|---|---|
+| Framework | React Native 0.76 (TypeScript) |
+| Navigation | React Navigation v7 (Native Stack) |
+| State Management | Zustand v5 |
+| HTTP Client | Axios |
+| Local Storage | AsyncStorage |
+| List Rendering | @shopify/flash-list |
+| Keyboard Handling | react-native-keyboard-controller |
+| Safe Area | react-native-safe-area-context |
 
-To start Metro, run the following command from the _root_ of your React Native project:
+---
+
+## Project Structure
+
+```
+orion-mobile/
+├── src/
+│   ├── components/
+│   │   ├── ChatBubble.tsx       # Individual message bubble (user/assistant)
+│   │   ├── InputBar.tsx         # Text input + send button
+│   │   ├── TypingIndicator.tsx  # Animated typing dots while AI responds
+│   │   └── index.ts
+│   ├── screens/
+│   │   ├── LoginScreen.tsx      # JWT login flow
+│   │   ├── RegisterScreen.tsx   # New user registration
+│   │   ├── ChatScreen.tsx       # Main chat interface
+│   │   └── index.ts
+│   ├── services/
+│   │   ├── api.ts               # Axios instance + auth/chat API calls
+│   │   ├── storage.ts           # AsyncStorage helpers (token, user, messages)
+│   │   └── index.ts
+│   ├── store/
+│   │   ├── authStore.ts         # Zustand auth state (login, register, logout)
+│   │   ├── chatStore.ts         # Zustand chat state (send, history, streaming)
+│   │   └── index.ts
+│   ├── types/                   # Shared TypeScript types
+│   └── utils/                   # Utility helpers
+├── App.tsx                      # Root navigator (Auth stack / Chat stack)
+├── index.js                     # App entry point
+├── .env.example                 # Environment variable template
+└── package.json
+```
+
+---
+
+## Prerequisites
+
+- **Node.js** >= 18
+- **React Native CLI** environment set up ([official guide](https://reactnative.dev/docs/environment-setup))
+- **Android Studio** + Android SDK (API 21+)
+- ORION backend running locally or deployed ([orion-backend](https://github.com/chiku0210/orion-backend))
+
+---
+
+## Getting Started
+
+### 1. Clone & Install
 
 ```bash
-# using npm
+git clone https://github.com/chiku0210/orion-mobile.git
+cd orion-mobile
+npm install
+```
+
+### 2. Configure Environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```env
+# Android emulator points to host machine at 10.0.2.2
+API_BASE_URL=http://10.0.2.2:3000
+
+# For physical device, use your machine's LAN IP
+# API_BASE_URL=http://192.168.x.x:3000
+```
+
+### 3. Start Metro
+
+```bash
 npm start
-
-# OR using Yarn
-yarn start
 ```
 
-## Step 2: Start your Application
-
-Let Metro Bundler run in its _own_ terminal. Open a _new_ terminal from the _root_ of your React Native project. Run the following command to start your _Android_ or _iOS_ app:
-
-### For Android
+### 4. Run on Android
 
 ```bash
-# using npm
 npm run android
-
-# OR using Yarn
-yarn android
 ```
 
-### For iOS
+---
 
-```bash
-# using npm
-npm run ios
+## Available Scripts
 
-# OR using Yarn
-yarn ios
-```
+| Script | Description |
+|---|---|
+| `npm start` | Start Metro bundler |
+| `npm run android` | Build and run on Android |
+| `npm run ios` | Build and run on iOS |
+| `npm test` | Run Jest tests |
+| `npm run lint` | ESLint check |
+| `npm run format` | Prettier format all files |
+| `npm run format:check` | Check formatting without writing |
 
-If everything is set up _correctly_, you should see your new app running in your _Android Emulator_ or _iOS Simulator_ shortly provided you have set up your emulator/simulator correctly.
+---
 
-This is one way to run your app — you can also run it directly from within Android Studio and Xcode respectively.
+## Features (Phase 1)
 
-## Step 3: Modifying your App
+- **Authentication** — Register and login with JWT tokens persisted via AsyncStorage
+- **Chat Interface** — Real-time messaging UI with user and AI bubbles
+- **Typing Indicator** — Animated dots while the AI generates a response
+- **Chat History** — Messages fetched from the backend on session restore
+- **State Management** — Zustand stores for auth (`authStore`) and chat (`chatStore`)
+- **API Layer** — Centralized Axios client with automatic token injection via interceptors
+- **Local Persistence** — Token, user info, and messages cached with AsyncStorage helpers
 
-Now that you have successfully run the app, let's modify it.
+---
 
-1. Open `App.tsx` in your text editor of choice and edit some lines.
-2. For **Android**: Press the <kbd>R</kbd> key twice or select **"Reload"** from the **Developer Menu** (<kbd>Ctrl</kbd> + <kbd>M</kbd> (on Window and Linux) or <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> (on macOS)) to see your changes!
+## Backend
 
-   For **iOS**: Hit <kbd>Cmd ⌘</kbd> + <kbd>R</kbd> in your iOS Simulator to reload the app and see your changes!
+This app connects to the ORION backend API. Make sure the backend is running before launching the app.
 
-## Congratulations! :tada:
+Backend repo: [chiku0210/orion-backend](https://github.com/chiku0210/orion-backend)
 
-You've successfully run and modified your React Native App. :partying_face:
+Expected endpoints:
 
-### Now what?
+| Method | Endpoint | Description |
+|---|---|---|
+| POST | `/auth/register` | Register a new user |
+| POST | `/auth/login` | Login and receive JWT |
+| POST | `/chat/send` | Send a message, get AI response |
+| GET | `/chat/history` | Fetch past conversation messages |
 
-- If you want to add this new React Native code to an existing application, check out the [Integration guide](https://reactnative.dev/docs/integration-with-existing-apps).
-- If you're curious to learn more about React Native, check out the [Introduction to React Native](https://reactnative.dev/docs/getting-started).
+---
 
-# Troubleshooting
+## Troubleshooting
 
-If you can't get this to work, see the [Troubleshooting](https://reactnative.dev/docs/troubleshooting) page.
-
-# Learn More
-
-To learn more about React Native, take a look at the following resources:
-
-- [React Native Website](https://reactnative.dev) - learn more about React Native.
-- [Getting Started](https://reactnative.dev/docs/environment-setup) - an **overview** of React Native and how setup your environment.
-- [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
-- [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
-- [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+- **Metro can't connect** — Make sure `API_BASE_URL` in `.env` matches where the backend is running.
+- **Android emulator network** — Use `10.0.2.2` to reach the host machine, not `localhost`.
+- **Physical device** — Use your machine's LAN IP and ensure the device is on the same Wi-Fi network.
+- **Build errors** — Run `cd android && ./gradlew clean` then retry `npm run android`.
+- **General RN issues** — See the [React Native Troubleshooting](https://reactnative.dev/docs/troubleshooting) docs.


### PR DESCRIPTION
## What changed

The existing `README.md` was the default React Native CLI boilerplate — it had zero relevance to the actual ORION project.

This PR replaces it with a proper, implementation-accurate README based on the current `main` branch code.

## What's documented

- **Project overview** — What ORION is, what it does
- **Tech stack table** — RN 0.76, Zustand v5, Axios, AsyncStorage, FlashList, react-native-keyboard-controller
- **Project structure** — Full `src/` tree with descriptions for every module (`components/`, `screens/`, `services/`, `store/`)
- **Getting started** — Clone, install, `.env` setup, Metro, Android run
- **Available scripts** — All scripts from `package.json` documented
- **Features (Phase 1)** — Auth, chat UI, typing indicator, history, Zustand state, API layer, local persistence
- **Backend API reference** — Links to `orion-backend`, lists expected endpoints
- **Troubleshooting** — Emulator networking, physical device, Gradle clean, etc.

## Checklist
- [x] Reflects actual code in `main`
- [x] No placeholder or boilerplate content
- [x] `.env.example` values documented
- [x] Backend repo linked
